### PR TITLE
resolve unapproval blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "intmax"
-version = "2.2.0-alpha"
+version = "2.2.1-alpha"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intmax"
-version = "2.2.0-alpha"
+version = "2.2.1-alpha"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  
+
   ![74763454](https://github.com/pucedoteth/intmax-rollup-cli/assets/119044801/2140fab8-a17b-4ae1-a95a-e8b464209e86)
     <h1>intmax</h1>
     <strong>The first stateless zkRollup</strong>
@@ -40,7 +40,7 @@ cargo run --release --bin intmax config aggregator-url https://alpha.testnet.int
 
 ```sh
 alias intmax="$(pwd)/target/release/intmax"
-intmax -V # intmax 2.2.0-alpha
+intmax -V # intmax 2.2.1-alpha
 ```
 
 ## Update

--- a/src/service/functions.rs
+++ b/src/service/functions.rs
@@ -89,6 +89,7 @@ pub async fn merge(
 
         wallet.backup()?;
 
+        service.resolve_server_health_issue().await.unwrap();
         service.trigger_propose_block().await.unwrap();
         service.trigger_approve_block().await.unwrap();
     }
@@ -147,6 +148,7 @@ pub async fn transfer(
         tx_hash
     };
 
+    service.resolve_server_health_issue().await.unwrap();
     service.trigger_propose_block().await.unwrap();
 
     {
@@ -225,6 +227,7 @@ pub async fn bulk_mint(
 
         service.deposit_assets(user_address, deposit_list).await?;
 
+        service.resolve_server_health_issue().await.unwrap();
         service.trigger_propose_block().await.unwrap();
         service.trigger_approve_block().await.unwrap();
     }


### PR DESCRIPTION
Prevent the following error from occurring in advance:

`thread 'main' panicked at 'called Result::unwrap() on an Err value: unexpected response from /account/register: too many requests for account registration, please wait until the next block is approved'`